### PR TITLE
Add Ksuid.newKsuid() convenience method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add the library to maven pom.xml (or the equivalent in your build system):
 Then simply generate a ksuid string like this:
 
 ```java
-String ksuid = KsuidGenerator.generate();
+String ksuid = Ksuid.newKsuid().toString();
 System.out.println(ksuid); // prints 1HCpXwx2EK9oYluWbacgeCnFcLf
 
 ```
@@ -51,23 +51,26 @@ private static final KsuidGenerator KSUID_GENERATOR = new KsuidGenerator(new Sec
 // Get a new Ksuid object.
 final Ksuid ksuid = ksuidGenerator.newKsuid();
 
-// The toString() method is the string representation of the object.
+// The toString() method is the string representation of KSUID.
 System.out.println("ksuid:\n" + ksuid  + "\n");
 
-// The string format is the KSUID represenation.
-System.out.println("ksuid.asString():\n" + ksuid.asString() + "\n");
+// The log string format shows some details on one line, suitable for logging.
+System.out.println("ksuid.toLogString():\n" + ksuid.toLogString() + "\n");
 
 // The inspect string format shows details.
 System.out.println("ksuid.toInspectString():\n" + ksuid.toInspectString());
 
 ```
 The output from the code block above is
+
 ```
 ksuid:
-Ksuid[timestamp = 150215977, payload = [124, 76, 43, -110, 116, -6, -91, 45, 0, -125, -127, 109, 28, 24, 28, -17], ksuidBytes = [8, -12, 29, 41, 124, 76, 43, -110, 116, -6, -91, 45, 0, -125, -127, 109, 28, 24, 28, -17]]
-
-ksuid.asString():
 1HCpXwx2EK9oYluWbacgeCnFcLf
+
+ksuid.toLogString():
+Ksuid[timestamp = 150215977, string = 1HCpXwx2EK9oYluWbacgeCnFcLf payload = [124, 76, 43, -110, 116, -6, \
+    -91, 45, 0, -125, -127, 109, 28, 24, 28, -17], ksuidBytes = [8, -12, 29, 41, 124, 76, 43, -110, 116, \
+    -6, -91, 45, 0, -125, -127, 109, 28, 24, 28, -17]]
 
 ksuid.toInspectString():
 REPRESENTATION:

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
-        <spring-boot-maven-plugin.version>2.4.4</spring-boot-maven-plugin.version>
 
         <!-- Specify all SonarQube code coverage reports - default does not pick up integration tests -->
         <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
@@ -297,22 +296,6 @@
                         </bannedDependencies>
                     </rules>
                 </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring-boot-maven-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build-info</goal>
-                        </goals>
-                        <configuration>
-                            <outputFile>${project.build.outputDirectory}/META-INF/build-info-${project.artifactId}.properties</outputFile>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
 
             <!-- https://maven.apache.org/plugins/maven-jar-plugin/ -->

--- a/src/main/java/com/github/ksuid/Ksuid.java
+++ b/src/main/java/com/github/ksuid/Ksuid.java
@@ -69,6 +69,33 @@ public class Ksuid implements Comparable<Ksuid> {
     }
 
     /**
+     * Static factory to retrieve a new Ksuid.
+     *
+     * The {@code Ksuid} is generated using a cryptographically strong pseudo
+     * random number generator.
+     *
+     * @return  A randomly generated {@code Ksuid}
+     */
+    public static Ksuid newKsuid() {
+        return KsuidGenerator.createKsuid();
+    }
+    
+    /**
+     * Creates a {@code Ksuid} from the string standard representation as
+     * described in the {@link #toString} method.
+     * 
+     * @param  ksuidString
+     *         A string that specifies a {@code Ksuid}
+     *
+     * @return  A {@code Ksuid} with the specified value
+     */
+    public static Ksuid fromString(final String ksuidString) {
+        return new Builder()
+                .withKsuidString(ksuidString)
+                .build();
+    }
+
+    /**
      * Get the KSUID as a byte array.
      *
      * @return KSUID bytes
@@ -78,12 +105,14 @@ public class Ksuid implements Comparable<Ksuid> {
     }
 
     /**
-     * Get the KSUID as a display string. e.g. <code>0ujtsYcgvSTl8PAuAdqWYSMnLOv</code>
+     * Returns a {@code String} object representing this {@code Ksuid}. <code>0ujtsYcgvSTl8PAuAdqWYSMnLOv</code>
      *
-     * @return KSUID display string
+     * @return  A string representation of this {@code Ksuid}
+     * @deprecated Use {@link #toString()}. Retained for backward-compatibility
      */
+    @Deprecated
     public String asString() {
-        return base62Encode(ksuidBytes, PAD_TO_LENGTH);
+        return toString();
     }
 
     /**
@@ -160,7 +189,25 @@ public class Ksuid implements Comparable<Ksuid> {
      */
     public String toInspectString() {
         return String.format("REPRESENTATION:%n%n  String: %1$s%n     Raw: %2$s%n%nCOMPONENTS:%n%n       Time: %3$s%n  Timestamp: %4$d%n    Payload: %5$s%n",
-                             asString(), asRaw(), getTime(), getTimestamp(), getPayload());
+                             toString(), asRaw(), getTime(), getTimestamp(), getPayload());
+    }
+
+    /**
+     * Get string representation suitable for logging. e.g.
+     * <pre>
+     * Ksuid[asString = 0ujtsYcgvSTl8PAuAdqWYSMnLOv, timestamp = 107608047, payload = [-75, ...], ksuidBytes = [6, ...]]
+     * </pre>
+     * 
+     * @return KSUID log string
+     * @see #toString()
+     */
+    public String toLogString() {
+        return new StringJoiner(", ", this.getClass().getSimpleName() + "[", "]")
+                .add("string = " + toString())
+                .add("timestamp = " + timestamp)
+                .add("payload = " + Arrays.toString(payload))
+                .add("ksuidBytes = " + Arrays.toString(ksuidBytes))
+                .toString();
     }
 
     @Override
@@ -188,21 +235,13 @@ public class Ksuid implements Comparable<Ksuid> {
     }
 
     /**
-     * Get toString representation. e.g.
-     * <pre>
-     * Ksuid[asString = 0ujtsYcgvSTl8PAuAdqWYSMnLOv, timestamp = 107608047, payload = [-75, ...], ksuidBytes = [6, ...]]
-     * </pre>
-     * 
-     * @see #asString()
+     * Returns a {@code String} object representing this {@code Ksuid}. <code>0ujtsYcgvSTl8PAuAdqWYSMnLOv</code>
+     *
+     * @return  A string representation of this {@code Ksuid}
      */
     @Override
     public String toString() {
-        return new StringJoiner(", ", this.getClass().getSimpleName() + "[", "]")
-                .add("asString = " + asString())
-                .add("timestamp = " + timestamp)
-                .add("payload = " + Arrays.toString(payload))
-                .add("ksuidBytes = " + Arrays.toString(ksuidBytes))
-                .toString();
+        return base62Encode(ksuidBytes, PAD_TO_LENGTH);
     }
 
     @Override

--- a/src/main/java/com/github/ksuid/KsuidGenerator.java
+++ b/src/main/java/com/github/ksuid/KsuidGenerator.java
@@ -23,14 +23,21 @@ public class KsuidGenerator {
     private final Supplier<byte[]> payloadSupplier;
 
     /**
-     * Generate a new KSUID
+     * Generate a new KSUID string representation
      * 
+     * The {@code Ksuid} is generated using a cryptographically strong pseudo
+     * random number generator.
+     *
      * @return string representation of new KSUID
      */
     public static String generate() {
-        return INSTANCE.newKsuid().asString();
+        return createKsuid().toString();
     }
-    
+
+    static Ksuid createKsuid() {
+        return INSTANCE.newKsuid();
+    }
+
     /**
      * Construct a KSUID generator.
      *

--- a/src/test/java/com/github/ksuid/KsuidTest.java
+++ b/src/test/java/com/github/ksuid/KsuidTest.java
@@ -51,8 +51,25 @@ public class KsuidTest {
     }
 
     @Theory
+    @SuppressWarnings("deprecation")
     public void asString(final Ksuid ksuid) {
         assertThat(ksuid.asString()).isEqualTo(KSUID_STRING);
+    }
+    
+    @Theory
+    public void toString(final Ksuid ksuid) {
+        assertThat(ksuid.toString()).isEqualTo(KSUID_STRING);
+    }
+
+    @Theory
+    public void fromString(final Ksuid ksuid) {
+        final String ksuidString = ksuid.toString();
+        assertThat(Ksuid.fromString(ksuidString)).isEqualTo(ksuid);
+    }
+    
+    @Test
+    public void testNewKsuid() {
+        assertThat(Ksuid.newKsuid()).isNotNull();
     }
 
     @Theory
@@ -93,8 +110,8 @@ public class KsuidTest {
     }
 
     @Theory
-    public void testToString(final Ksuid ksuid) {
-        assertThat(ksuid.toString()).isEqualTo("Ksuid[asString = 0ujtsYcgvSTl8PAuAdqWYSMnLOv"  + 
+    public void testToLogString(final Ksuid ksuid) {
+        assertThat(ksuid.toLogString()).isEqualTo("Ksuid[string = 0ujtsYcgvSTl8PAuAdqWYSMnLOv"  +
                                                        ", timestamp = " + TIMESTAMP +
                                                        ", payload = [-75, -95, -51, 52, -75, -7, -99, 17, 84, -5, 104, 83, 52, 92, -105, 53]" +
                                                        ", ksuidBytes = [6, 105, -9, -17, -75, -95, -51, 52, -75, -7, -99, 17, 84, -5, 104, 83, 52, 92, -105, 53]]");


### PR DESCRIPTION
Add Ksuid.newKsuid() convenience method.

To mirror UUID.randomUUID() method, add Ksuid.newKsuid() method.

To further mirror UUID.randomUUID().toString() calls, change toString()
to return a display string representation, e.g. 0ujtsYcgvSTl8PAuAdqWYSMnLOv

This is technically a backward-incompatible change. Previous toString()
method is available as new toLogString() method.

Existing asString() method is now deprecated in favor of updated toString()
method.

Lastly, add Ksuid.fromString(string) method mirroring UUID.fromString(string)

Fixes issue #3